### PR TITLE
Fix color inconsistency

### DIFF
--- a/test/colorHelpers.spec.js
+++ b/test/colorHelpers.spec.js
@@ -1,0 +1,11 @@
+import {
+    transformHexToRgb,
+} from '../web/lib/helpers/colorHelpers'
+
+test('#transformHexToRgb', () => {
+    expect(transformHexToRgb(5636095)).toEqual({
+        r: 85,
+        g: 255,
+        b: 255
+    })
+})

--- a/test/dataHelpers.spec.js
+++ b/test/dataHelpers.spec.js
@@ -7,79 +7,110 @@ import {
     addColor,
     combineLEDs,
     regroupConfig,
-    transformHexToRgb,
     putLedsInBufferArray,
     eliminateLEDsConfigRepetition
 } from '../web/lib/helpers/dataHelpers'
 
-test('#transformHexToRgb', () => {
-    expect(transformHexToRgb(5636095)).toEqual({
-        r: 85,
-        g: 255,
+test('#addColor', () => {
+    const first = {
+        r: 13,
+        g: 24,
+        b: 253
+    }
+    const second = {
+        r: 100,
+        g: 200,
+        b: 20
+    }
+    expect(addColor(first, second)).toEqual({
+        r: 113,
+        g: 224,
         b: 255
     })
-})
-
-test('#addColor', () => {
-    const first = 256 * 256 * 13 + 256 * 24 + 253
-    const second = 256 * 256 * 100 + 256 * 200 + 20
-    expect(addColor(first, second)).toEqual(256 * 256 * 113 + 256 * 224 + 255)
 })
 
 test('#combineLEDs', () => {
     const first = [{
         number: 10,
-        color: 256 * 256 * 13 + 256 * 24 + 253
+        color: {
+            r: 13,
+            g: 24,
+            b: 253
+        }
     }, {
         number: 11,
-        color: 256 * 256 * 13 + 256 * 24 + 253
+        color: {
+            r: 13,
+            g: 24,
+            b: 253
+        }
     }]
     const second = [{
         number: 10,
-        color: 256 * 256 * 100 + 256 * 200 + 20
+        color: {
+            r: 100,
+            g: 200,
+            b: 20
+        }
     }, {
         number: 12,
-        color: 256 * 256 * 100 + 256 * 200 + 20
+        color: {
+            r: 100,
+            g: 200,
+            b: 20
+        }
     }]
     expect(combineLEDs(first, second)).toEqual([{
         number: 10,
-        color: 256 * 256 * 113 + 256 * 224 + 255
+        color: {
+            r: 113,
+            g: 224,
+            b: 255
+        }
     }, {
         number: 11,
-        color: 256 * 256 * 13 + 256 * 24 + 253
+        color: {
+            r: 13,
+            g: 24,
+            b: 253
+        }
     }, {
         number: 12,
-        color: 256 * 256 * 100 + 256 * 200 + 20
+        color: {
+            r: 100,
+            g: 200,
+            b: 20
+        }
     }])
 })
 
 test('eliminateLEDsConfigRepetition', () => {
-    const ledsConfig = [{ number: 10, color: 256 * 256 * 13 + 256 * 24 + 17 }, { number: 10, color: 256 * 256 * 9 + 256 * 100 + 253 }, { number: 9, color: 255 }]
-    expect(eliminateLEDsConfigRepetition(ledsConfig)).toEqual([{ number: 10, color: 256 * 256 * 13 + 256 * 100 + 253 }, { number: 9, color: 255 }])
+    const ledsConfig = [{ number: 10, color: { r: 13, g: 24, b: 17 } }, { number: 10, color: { r: 9, g: 100, b: 253 } }, { number: 9, color: { r: 0, g: 0, b: 255 } }]
+    expect(eliminateLEDsConfigRepetition(ledsConfig)).toEqual([{ number: 10, color: { r: 13, g: 100, b: 253 } }, { number: 9, color: { r: 0, g: 0, b: 255 } }])
 })
 
 test('#regroupConfig', () => {
     const ledsConfig = [[
-        { key: '1', leds: [{ number: 10, color: 1 }, { number: 9, color: 2 }, { number: 8, color: 3 }] },
-        { key: '2', leds: [{ number: 10, color: 4 }, { number: 11, color: 5 }, { number: 8, color: 6 }] },
-        { key: '3', leds: [{ number: 10, color: 4 }, { number: 11, color: 5 }, { number: 8, color: 6 }] }
+        { key: '1', leds: [{ number: 10, color: { r: 0, g: 0, b: 1 } }, { number: 9, color: { r: 0, g: 0, b: 2 } }, { number: 8, color: { r: 0, g: 0, b: 3 } }] },
+        { key: '2', leds: [{ number: 10, color: { r: 0, g: 0, b: 4 } }, { number: 11, color: { r: 0, g: 0, b: 5 } }, { number: 8, color: { r: 0, g: 0, b: 6 } }] },
+        { key: '3', leds: [{ number: 10, color: { r: 0, g: 0, b: 4 } }, { number: 11, color: { r: 0, g: 0, b: 5 } }, { number: 8, color: { r: 0, g: 0, b: 6 } }] }
     ], [
-        { key: '1', leds: [{ number: 10, color: 7 }, { number: 7, color: 8 }, { number: 8, color: 9 }] },
-        { key: '2', leds: [{ number: 10, color: 10 }, { number: 12, color: 11 }, { number: 14, color: 12 }] },
-        { key: '2', leds: [{ number: 10, color: 10 }, { number: 12, color: 11 }, { number: 14, color: 12 }] }
+        { key: '1', leds: [{ number: 10, color: { r: 0, g: 0, b: 7 } }, { number: 7, color: { r: 0, g: 0, b: 8 } }, { number: 8, color: { r: 0, g: 0, b: 9 } }] },
+        { key: '2', leds: [{ number: 10, color: { r: 0, g: 0, b: 10 } }, { number: 12, color: { r: 0, g: 0, b: 11 } }, { number: 14, color: { r: 0, g: 0, b: 12 } }] },
+        { key: '2', leds: [{ number: 10, color: { r: 0, g: 0, b: 10 } }, { number: 12, color: { r: 0, g: 0, b: 11 } }, { number: 14, color: { r: 0, g: 0, b: 12 } }] }
     ]]
 
     const expected = [
-        { key: '1', leds: [{ number: 10, color: 8 }, { number: 9, color: 2 }, { number: 8, color: 12 }, { number: 7, color: 8 }] },
-        { key: '2', leds: [{ number: 10, color: 24 }, { number: 11, color: 5 }, { number: 8, color: 6 }, { number: 12, color: 22 }, { number: 14, color: 24 }] },
-        { key: '3', leds: [{ number: 10, color: 4 }, { number: 11, color: 5 }, { number: 8, color: 6 }] }
+        { key: '1', leds: [{ number: 10, color: { r: 0, g: 0, b: 8 } }, { number: 9, color: { r: 0, g: 0, b: 2 } }, { number: 8, color: { r: 0, g: 0, b: 12 } }, { number: 7, color: { r: 0, g: 0, b: 8 } }] },
+        { key: '2', leds: [{ number: 10, color: { r: 0, g: 0, b: 24 } }, { number: 11, color: { r: 0, g: 0, b: 5 } }, { number: 8, color: { r: 0, g: 0, b: 6 } }, { number: 12, color: { r: 0, g: 0, b: 22 } }, { number: 14, color: { r: 0, g: 0, b: 24 } }] },
+        { key: '3', leds: [{ number: 10, color: { r: 0, g: 0, b: 4 } }, { number: 11, color: { r: 0, g: 0, b: 5 } }, { number: 8, color: { r: 0, g: 0, b: 6 } }] }
     ]
 
     expect(regroupConfig(ledsConfig)).toEqual(expected)
 })
 
 test('#putLedsInBufferArray', () => {
-    const leds = [{ number: 0, color: 7 }, { number: 1, color: 8 }, { number: 2, color: 9 }]
+    const leds = [{ number: 0, color: { r: 0, g: 0, b: 7 } }, { number: 1, color: { r: 0, g: 0, b: 8 } }, { number: 2, color: { r: 0, g: 0, b: 9 } }]
     const buffer = new ArrayBuffer(3 * leds.length + 3)
     const expected = new Uint8Array(buffer)
     expected.set([0x10, 0x11, 0, 0, 7, 0, 0, 8, 0, 0, 9, 0x12], 0)

--- a/web/lib/classes/clientStick.js
+++ b/web/lib/classes/clientStick.js
@@ -1,4 +1,4 @@
-import { transformRgbToHex } from "../helpers/colorHelpers";
+import { transformRgbToHex } from '../helpers/colorHelpers.js'
 
 const INIT_STICK_COLOR = 0x222244
 

--- a/web/lib/classes/clientStick.js
+++ b/web/lib/classes/clientStick.js
@@ -1,3 +1,5 @@
+import { transformRgbToHex } from "../helpers/colorHelpers";
+
 const INIT_STICK_COLOR = 0x222244
 
 export class ClientStick {
@@ -22,8 +24,4 @@ export class ClientStick {
 			led.material.color.setHex(INIT_STICK_COLOR)
 		})
 	}
-}
-
-const transformRgbToHex = ({ r, g, b }) => {
-	return 0x1000000 + b + 0x100 * g + 0x10000 * r
 }

--- a/web/lib/classes/clientStick.js
+++ b/web/lib/classes/clientStick.js
@@ -12,7 +12,8 @@ export class ClientStick {
 		this.cleanLeds()
 
 		leds.forEach(led => {
-			this.StickLEDs[led.number].material.color.setHex(led.color)
+			const hexColor = transformRgbToHex(led.color)
+			this.StickLEDs[led.number].material.color.setHex(hexColor)
 		})
 	}
 
@@ -21,4 +22,8 @@ export class ClientStick {
 			led.material.color.setHex(INIT_STICK_COLOR)
 		})
 	}
+}
+
+const transformRgbToHex = ({ r, g, b }) => {
+	return 0x1000000 + b + 0x100 * g + 0x10000 * r
 }

--- a/web/lib/helpers/colorHelpers.js
+++ b/web/lib/helpers/colorHelpers.js
@@ -1,0 +1,17 @@
+const transformHexToRgb = (hex) => {
+    const b = hex % 256
+    const g = (hex - b) / 256 % 256
+    const r = ((hex - b) / 256 - g) / 256
+    return {
+        r, g, b
+    }
+}
+
+const transformRgbToHex = ({ r, g, b }) => {
+    return 0x1000000 + b + 0x100 * g + 0x10000 * r
+}
+
+export {
+    transformHexToRgb,
+    transformRgbToHex
+}

--- a/web/lib/helpers/dataHelpers.js
+++ b/web/lib/helpers/dataHelpers.js
@@ -2,6 +2,8 @@
 /* global ArrayBuffer */
 /* global Uint8Array */
 
+import { transformHexToRgb } from './colorHelpers.js'
+
 const putLedsInBufferArray = (columnLedsConfig, numberOfLeds) => {
     const bufferArray = new ArrayBuffer(numberOfLeds * 3 + 3)
     const ledsBufferArray = new Uint8Array(bufferArray)
@@ -12,7 +14,7 @@ const putLedsInBufferArray = (columnLedsConfig, numberOfLeds) => {
     ledsBufferArray[0] = startByte
     ledsBufferArray[1] = sizeByte
     columnLedsConfig.slice(0, numberOfLeds).forEach(led => {
-        const rgb = transformHexToRgb(led.color)
+        const rgb = led.color
         ledsBufferArray[led.number * 3 + 2] = rgb.r
         ledsBufferArray[led.number * 3 + 3] = rgb.g
         ledsBufferArray[led.number * 3 + 4] = rgb.b
@@ -22,11 +24,11 @@ const putLedsInBufferArray = (columnLedsConfig, numberOfLeds) => {
 }
 
 const addColor = (ledOne, ledTwo) => {
-    const ledOneRGB = transformHexToRgb(ledOne)
-    const ledTwoRGB = transformHexToRgb(ledTwo)
-    return Math.min(ledOneRGB.r + ledTwoRGB.r, 255) * 256 * 256
-        + Math.min(ledOneRGB.g + ledTwoRGB.g, 255) * 256
-        + Math.min(ledOneRGB.b + ledTwoRGB.b, 255)
+    return {
+        r: Math.min(ledOne.r + ledTwo.r, 255),
+        g: Math.min(ledOne.g + ledTwo.g, 255),
+        b: Math.min(ledOne.b + ledTwo.b, 255)
+    }
 }
 
 const combineLEDs = (first, second) => {
@@ -56,9 +58,13 @@ const eliminateLEDsConfigRepetition = (ledsConfig) => {
             cleanedConfig.push(led)
             return
         }
-        const oldColor = transformHexToRgb(foundLed.color)
-        const newColor = transformHexToRgb(led.color)
-        const color = Math.max(oldColor.r, newColor.r) * 256 * 256 + Math.max(oldColor.g, newColor.g) * 256 + Math.max(oldColor.b, newColor.b)
+        const oldColor = foundLed.color
+        const newColor = led.color
+        const color = {
+            r: Math.max(oldColor.r, newColor.r),
+            g: Math.max(oldColor.g, newColor.g),
+            b: Math.max(oldColor.b, newColor.b)
+        }
         cleanedConfig[cleanedConfig.indexOf(foundLed)] = {
             number: foundLed.number,
             color
@@ -77,7 +83,7 @@ const regroupConfig = (ledsConfig) => {
             if (!found) {
                 regroupedConfig.push(stickConfig)
             } else {
-                found.leds = combineLEDs(found.leds, stickConfig.leds)
+                found.leds = combineLEDs([...found.leds], stickConfig.leds)
             }
         })
     })

--- a/web/lib/helpers/dataHelpers.js
+++ b/web/lib/helpers/dataHelpers.js
@@ -85,20 +85,10 @@ const regroupConfig = (ledsConfig) => {
     return regroupedConfig
 }
 
-const transformHexToRgb = (hex) => {
-    const b = hex % 256
-    const g = (hex - b) / 256 % 256
-    const r = ((hex - b) / 256 - g) / 256
-    return {
-        r, g, b
-    }
-}
-
 export {
     addColor,
     combineLEDs,
     regroupConfig,
-    transformHexToRgb,
     putLedsInBufferArray,
     eliminateLEDsConfigRepetition
 }

--- a/web/lib/modes/basic.js
+++ b/web/lib/modes/basic.js
@@ -1,5 +1,9 @@
 const basic = (sticks, sensors) => {
-	const brightColor = 0xffeeee
+	const brightColor = {
+		r: 200,
+		g: 200,
+		b: 255
+	}
 
 	return sensors.map(sensor => {
 		const stick = sticks.find(stick => stick.name === sensor.column)

--- a/web/lib/modes/flicker.js
+++ b/web/lib/modes/flicker.js
@@ -1,5 +1,15 @@
 const flicker = (sticks, sensors) => {
-	const brightColor = 0xffeeee
+	const brightColor = {
+		r: 200,
+		g: 200,
+		b: 255
+	}
+
+	const offColor = { // get from contants
+		r: 34,
+		g: 34,
+		b: 68
+	}
 
 	return sensors.map(sensor => {
 		const stick = sticks.find(stick => stick.name === sensor.column)
@@ -12,7 +22,7 @@ const flicker = (sticks, sensors) => {
 		for (let key = 0; key < numberOfLEDs; key++) {
 			const ledColor = tension / numberOfLEDs > Math.random()
 				? brightColor
-				: 0x222244
+				: offColor
 
 			leds.push({
 				number: key,

--- a/web/lib/modes/rain.js
+++ b/web/lib/modes/rain.js
@@ -49,8 +49,4 @@ const rain = (sticks, sensors) => {
 	})
 }
 
-const transformRgbToHex = ({ r, g, b }) => {
-	return 0x1000000 + b + 0x100 * g + 0x10000 * r
-}
-
 export default rain

--- a/web/lib/modes/rain.js
+++ b/web/lib/modes/rain.js
@@ -1,4 +1,4 @@
-import {transformHexToRgb} from '../helpers/dataHelpers'
+import { transformHexToRgb } from '../helpers/dataHelpers'
 
 const rain = (sticks, sensors) => {
 
@@ -13,7 +13,7 @@ const rain = (sticks, sensors) => {
 		const numberOfLEDs = stick.numberOfLEDs
 
 		const leds = []
-		
+
 
 		for (let key = 0; key < numberOfLEDs; key++) {
 			//const ledColor = tension / numberOfLEDs > Math.random()
@@ -31,7 +31,7 @@ const rain = (sticks, sensors) => {
 				red = previousColor.r - reduceBrightness
 				green = previousColor.g - reduceBrightness
 				blue = previousColor.b - reduceBrightness
-				
+
 			}
 
 			ledColor1 = RGB2HTML(red, green, blue)
@@ -49,9 +49,8 @@ const rain = (sticks, sensors) => {
 	})
 }
 
-function RGB2HTML(red, green, blue) {
-	var decColor = 0x1000000 + blue + 0x100 * green + 0x10000 * red;
-	return decColor;
+const transformRgbToHex = ({ r, g, b }) => {
+	return 0x1000000 + b + 0x100 * g + 0x10000 * r
 }
 
 export default rain

--- a/web/lib/modes/randomEcho.js
+++ b/web/lib/modes/randomEcho.js
@@ -16,11 +16,13 @@ const randomEcho = (sticks, sensors) => {
 
 			for (let key = 0; key < stick.numberOfLEDs; key++) {
 				const colorIntensity = parseInt(255 * Math.random())
-				const rgbColor = `rgba(${Math.floor(15 / (distance / 244 + 1))}, ${Math.floor(colorIntensity / (distance / 244 + 1))}, ${Math.floor(200 / (distance / 244 + 1))})`
-				const color = new THREE.Color(rgbColor)
 				leds.push({
 					number: key,
-					color
+					color: {
+						r: Math.floor(15 / (distance / 244 + 1)),
+						g: Math.floor(colorIntensity / (distance / 244 + 1)),
+						b: Math.floor(200 / (distance / 244 + 1))
+					}
 				})
 			}
 

--- a/web/lib/modes/tensionAndRandomEcho.js
+++ b/web/lib/modes/tensionAndRandomEcho.js
@@ -21,25 +21,41 @@ const tensionAndRandomEcho = (sticks, sensors) => {
 							if (distance === 0) {
 								leds.push({
 									number: Math.max(sensor.sensorPosition - key, 0),
-									color: new THREE.Color(`rgba(${Math.floor(60 + Math.random() * 195)}, ${Math.floor(60 + Math.random() * 195)}, ${Math.floor(60 + Math.random() * 195)})`)
+									color: {
+										r: Math.floor(60 + Math.random() * 195),
+										g: Math.floor(60 + Math.random() * 195),
+										b: Math.floor(60 + Math.random() * 195)
+									}
 								})
 								leds.push({
 									number: Math.min(sensor.sensorPosition + key, numberOfLEDs - 1),
-									color: new THREE.Color(`rgba(${Math.floor(60 + Math.random() * 195)}, ${Math.floor(60 + Math.random() * 195)}, ${Math.floor(60 + Math.random() * 195)})`)
+									color: {
+										r: Math.floor(60 + Math.random() * 195),
+										g: Math.floor(60 + Math.random() * 195),
+										b: Math.floor(60 + Math.random() * 195)
+									}
 								})
 							} else {
 								if (tension > sensor.sensorPosition) {
 									let dif = Math.min(Math.floor(tension - sensor.sensorPosition), numberOfLEDs - 1)
 									leds.push({
 										number: dif,
-										color: new THREE.Color(`rgba(${Math.floor(60 + Math.random() * 195)}, ${Math.floor(60 + Math.random() * 195)}, ${Math.floor(60 + Math.random() * 195)})`)
+										color: {
+											r: Math.floor(60 + Math.random() * 195),
+											g: Math.floor(60 + Math.random() * 195),
+											b: Math.floor(60 + Math.random() * 195)
+										}
 									})
 								}
 								if (tension > numberOfLEDs - sensor.sensorPosition) {
 									let dif = Math.min(Math.floor(tension - numberOfLEDs + sensor.sensorPosition), numberOfLEDs - 1)
 									leds.push({
 										number: numberOfLEDs - 1 - dif,
-										color: new THREE.Color(`rgba(${Math.floor(60 + Math.random() * 195)}, ${Math.floor(60 + Math.random() * 195)}, ${Math.floor(60 + Math.random() * 195)})`)
+										color: {
+											r: Math.floor(60 + Math.random() * 195),
+											g: Math.floor(60 + Math.random() * 195),
+											b: Math.floor(60 + Math.random() * 195)
+										}
 									})
 								}
 							}
@@ -48,7 +64,11 @@ const tensionAndRandomEcho = (sticks, sensors) => {
 						if (sensor.column === stick.name && tension >= 10) {
 							[...Array(stick.numberOfLEDs)].map((el, key) => leds.push({
 								number: key,
-								color: new THREE.Color(`rgba(255, 0, 0)`)
+								color: {
+									r: 255,
+									g: 0,
+									b: 0
+								}
 							}))
 						}
 					}

--- a/web/server.js
+++ b/web/server.js
@@ -84,10 +84,9 @@ io.on('connection', socket => {
 		} // TODO: logging
 
 		const ledsConfigFromClient = currentMode(sticks, sensors).filter(Boolean)
-		// console.log(ledsConfigFromClient[0][0].leds)
-		// ledsConfig = regroupConfig(ledsConfigFromClient)
-		// socket.emit('ledsChanged', ledsConfig)
-		ledsConfigFromClient.map(ledConfig => socket.emit('ledsChanged', ledConfig)) // keep for now for development processes
+		ledsConfig = regroupConfig(ledsConfigFromClient)
+		socket.emit('ledsChanged', ledsConfig)
+		// ledsConfigFromClient.map(ledConfig => socket.emit('ledsChanged', ledConfig)) // keep for now for development processes
 	})
 
 	socket.on('configure', configuration => {

--- a/web/server.js
+++ b/web/server.js
@@ -84,9 +84,10 @@ io.on('connection', socket => {
 		} // TODO: logging
 
 		const ledsConfigFromClient = currentMode(sticks, sensors).filter(Boolean)
-		ledsConfig = regroupConfig(ledsConfigFromClient)
-		socket.emit('ledsChanged', ledsConfig)
-		// ledsConfigFromClient.map(ledConfig => socket.emit('ledsChanged', ledConfig)) // keep for now for development processes
+		// console.log(ledsConfigFromClient[0][0].leds)
+		// ledsConfig = regroupConfig(ledsConfigFromClient)
+		// socket.emit('ledsChanged', ledsConfig)
+		ledsConfigFromClient.map(ledConfig => socket.emit('ledsChanged', ledConfig)) // keep for now for development processes
 	})
 
 	socket.on('configure', configuration => {


### PR DESCRIPTION
Get rid of aligning everything to hex, and therefore non-necessary calculations.

Post this PR:
 - all colours are being transformed as {r,g,b} object
 -  gets converted to hex once - when colour THREE objects
 - fixes bug: Echo - goes black after a while